### PR TITLE
Fix database migration

### DIFF
--- a/training/database/database.py
+++ b/training/database/database.py
@@ -1,7 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from training.config import settings
-from training.models import Base
 
 
 # cloud.gov provides the URI in postgres:// format, but SQLAlchemy requires

--- a/training/database/database.py
+++ b/training/database/database.py
@@ -11,7 +11,3 @@ db_uri = settings.DB_URI.replace("postgres://", "postgresql://")
 engine = create_engine(db_uri)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-# TODO: Alembic migrations
-Base.metadata.create_all(engine)


### PR DESCRIPTION
Now that we're using Alembic for migrations, this bit of code telling SQLAlchemy to automatically create tables should actually be removed.