### PR TITLE
remove the beforeunload handler after the quiz is submitted

### DIFF
--- a/training-front-end/src/components/Quiz.vue
+++ b/training-front-end/src/components/Quiz.vue
@@ -43,6 +43,7 @@
 
   onBeforeUnmount(() => {
     window.removeEventListener('popstate', windowStateListener)
+    window.removeEventListener('beforeunload', exit_warning)
   })
 
   function next_question(){

--- a/training-front-end/src/components/QuizIndex.vue
+++ b/training-front-end/src/components/QuizIndex.vue
@@ -20,7 +20,6 @@
     }
     const filtered_quizzes =  await res.json();
     quiz.value = filtered_quizzes[0]
-    console.log("quiz: ", quiz.value)
   })
 
   onErrorCaptured((err) => {

--- a/training-front-end/src/components/QuizResults.vue
+++ b/training-front-end/src/components/QuizResults.vue
@@ -12,10 +12,6 @@
     const percentage = computed(() => (props.quizResults.percentage * 100).toFixed(0))
     const questions_incorrect = computed(() => quiz_questions.filter((q, i) => !props.quizResults.questions[i].correct))
 
-    function exit_warning(event) {
-      event.preventDefault()
-      return event.returnValue = "Are you sure you want to exit?";
-    }
     
     function windowStateListener(event) {
       window.location = import.meta.env.BASE_URL
@@ -23,7 +19,6 @@
 
     onMounted(() => {
       // send to API
-      window.addEventListener("beforeunload", exit_warning)
       window.addEventListener("popstate", windowStateListener)
     })
 


### PR DESCRIPTION
- Removes the `beforeunload` handler when the quiz unmounts so navigating away from quiz results does not ask 'are you sure'.
- Removes the unneeded `beforeunload` on quiz results