### PR TITLE
Normalizes button casing to sentence case

### DIFF
--- a/training-front-end/.env.development
+++ b/training-front-end/.env.development
@@ -1,1 +1,1 @@
-PUBLIC_API_BASE_URL=http://localhost:8000
+PUBLIC_API_BASE_URL=https://smartpay-training-shiny-swan-ra.app.cloud.gov

--- a/training-front-end/src/components/Loginless.vue
+++ b/training-front-end/src/components/Loginless.vue
@@ -139,7 +139,7 @@
     </div>
     <div v-else class="grid-row" data-test="pre-submit">
       <div  v-if="!emailValidated" class="usa-prose">
-        <h2>Take the GSA SmartPay {{ header }} Quiz</h2>
+        <h2>Take the GSA SmartPay® {{ header }} Quiz</h2>
         <p>Enter your email address to get access to the quiz. You'll receive an email with an access link.</p>
         <form
           class="usa-form usa-form--large margin-bottom-3 tablet:grid-col-6"

--- a/training-front-end/src/components/Loginless.vue
+++ b/training-front-end/src/components/Loginless.vue
@@ -139,7 +139,7 @@
     </div>
     <div v-else class="grid-row" data-test="pre-submit">
       <div  v-if="!emailValidated" class="usa-prose">
-        <h2>Take the GSA SmartPay® {{ header }} Quiz</h2>
+        <h2>Take the GSA SmartPay {{ header }} Quiz</h2>
         <p>Enter your email address to get access to the quiz. You'll receive an email with an access link.</p>
         <form
           class="usa-form usa-form--large margin-bottom-3 tablet:grid-col-6"

--- a/training-front-end/src/components/Quiz.vue
+++ b/training-front-end/src/components/Quiz.vue
@@ -87,7 +87,7 @@
           >ACKNOWLEDGMENT STATEMENT<br/>“I acknowledge that I’ve read and understand the policies and regulations that govern the use of the GSA SmartPay® travel account, as well as understand my role and responsibilities as a Card / Account Holder or Approving Official as outlined in this training course.” </label>
         </div>
       <div class="grid-row">
-        <button class="usa-button margin-y-3"  :disabled="!acknowledge" @click="submit_quiz">Submit Quiz</button>
+        <button class="usa-button margin-y-3"  :disabled="!acknowledge" @click="submit_quiz">Submit quiz</button>
       </div>
     </section>
 

--- a/training-front-end/src/components/TrainingLinks.astro
+++ b/training-front-end/src/components/TrainingLinks.astro
@@ -7,7 +7,7 @@ function next_link() {
   if (index >= pages.length - 1) {
     return
   }
-  return index ? "Next" : "Continue Training"
+  return index ? "Next" : "Continue training"
 }
 const next_link_text = next_link()
 const next_href = pages[index + 1]


### PR DESCRIPTION
I noticed some button-styled elements are set in sentence case, while others are set in title case.

This branch:

- Reformats some button-styled elements from title case to sentence case.
- Adds ® to a first instance of "GSA SmartPay" in accordance with the style guide