### PR TITLE
Enforce validation on quiz topic/audience and question type fields

### DIFF
--- a/training/schemas/__init__.py
+++ b/training/schemas/__init__.py
@@ -2,9 +2,9 @@ from .agency import Agency, AgencyCreate
 from .temp_user import TempUser, IncompleteTempUser, WebDestination
 from .user import User, UserCreate
 from .quiz_choice import QuizChoice, QuizChoiceCreate, QuizChoicePublic
-from .quiz_question import QuizQuestion, QuizQuestionCreate, QuizQuestionPublic
+from .quiz_question import QuizQuestion, QuizQuestionCreate, QuizQuestionPublic, QuizQuestionType
 from .quiz_content import QuizContent, QuizContentCreate, QuizContentPublic
-from .quiz import Quiz, QuizCreate, QuizPublic
+from .quiz import Quiz, QuizCreate, QuizPublic, QuizTopic, QuizAudience
 from .quiz_submission import QuizSubmission
 from .quiz_grade import QuizGrade
 from .quiz_completion import QuizCompletion, QuizCompletionCreate

--- a/training/schemas/quiz.py
+++ b/training/schemas/quiz.py
@@ -1,11 +1,23 @@
+from enum import Enum
 from pydantic import BaseModel
 from training.schemas import QuizContent, QuizContentCreate, QuizContentPublic
 
 
+class QuizTopic(str, Enum):
+    Travel = "Travel"
+    Purchase = "Purchase"
+    Fleet = "Fleet"
+
+
+class QuizAudience(str, Enum):
+    AccountHoldersApprovingOfficials = "AccountHoldersApprovingOfficials"
+    ProgramCoordinators = "ProgramCoordinators"
+
+
 class QuizBase(BaseModel):
     name: str
-    topic: str
-    audience: str
+    topic: QuizTopic
+    audience: QuizAudience
     active: bool
     content: QuizContent
 

--- a/training/schemas/quiz_question.py
+++ b/training/schemas/quiz_question.py
@@ -1,10 +1,16 @@
+from enum import Enum
 from pydantic import BaseModel
 from training.schemas import QuizChoice, QuizChoicePublic, QuizChoiceCreate
 
 
+class QuizQuestionType(str, Enum):
+    MultipleChoiceMultipleSelect = "MultipleChoiceMultipleSelect"
+    MultipleChoiceSingleSelect = "MultipleChoiceSingleSelect"
+
+
 class QuizQuestionBase(BaseModel):
     text: str
-    type: str
+    type: QuizQuestionType
     choices: list[QuizChoice]
 
 

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -219,9 +219,40 @@ def invalid_submission(testdata: dict) -> Generator[schemas.QuizSubmission, None
 @pytest.fixture
 def valid_quiz(testdata: dict) -> Generator[models.Quiz, None, None]:
     '''
-    Provides a valid Quiz schema object.
+    Provides a valid Quiz database model object.
     '''
     jsondata = testdata["quizzes"][0]
     db_quiz = models.Quiz(**jsondata)
     db_quiz.id = 123
     yield db_quiz
+
+
+@pytest.fixture
+def valid_quiz_create() -> schemas.QuizCreate:
+    '''
+    Provides a valid QuizCreate schema object.
+    '''
+    return schemas.QuizCreate(
+        name="New Quiz",
+        topic=schemas.QuizTopic.Travel,
+        audience=schemas.QuizAudience.AccountHoldersApprovingOfficials,
+        active=True,
+        content=schemas.QuizContentCreate(
+            questions=[
+                schemas.QuizQuestionCreate(
+                    type=schemas.QuizQuestionType.MultipleChoiceSingleSelect,
+                    text="Official ministry travel is performed via the floo network.",
+                    choices=[
+                        schemas.QuizChoiceCreate(
+                            text="True.",
+                            correct=True
+                        ),
+                        schemas.QuizChoiceCreate(
+                            text="True.",
+                            correct=True
+                        )
+                    ]
+                )
+            ]
+        )
+    )

--- a/training/tests/test_quiz_repository.py
+++ b/training/tests/test_quiz_repository.py
@@ -1,34 +1,5 @@
-import pytest
 from training import schemas
 from training.repositories import QuizRepository
-
-
-@pytest.fixture
-def valid_quiz_create() -> schemas.QuizCreate:
-    return schemas.QuizCreate(
-        name="New Quiz",
-        topic="Travel",
-        audience="AccountHoldersApprovingOfficials",
-        active=True,
-        content=schemas.QuizContentCreate(
-            questions=[
-                schemas.QuizQuestionCreate(
-                    type="MultipleChoiceSingleSelect",
-                    text="Official ministry travel is performed via the floo network.",
-                    choices=[
-                        schemas.QuizChoiceCreate(
-                            text="True.",
-                            correct=True
-                        ),
-                        schemas.QuizChoiceCreate(
-                            text="True.",
-                            correct=True
-                        )
-                    ]
-                )
-            ]
-        )
-    )
 
 
 def test_create(quiz_repo_empty: QuizRepository, valid_quiz_create: schemas.QuizCreate):
@@ -47,8 +18,8 @@ def test_create_duplicate(quiz_repo_empty: QuizRepository, valid_quiz_create: sc
 
 def test_find_by_type(quiz_repo_with_data: QuizRepository):
     result = quiz_repo_with_data.find_all(filters={
-        "topic": "Travel",
-        "audience": "Wizards",
+        "topic": schemas.QuizTopic.Travel,
+        "audience": schemas.QuizAudience.AccountHoldersApprovingOfficials,
         "active": True
     })
     assert len(result) == 1

--- a/training/tests/test_quiz_schemas.py
+++ b/training/tests/test_quiz_schemas.py
@@ -1,0 +1,25 @@
+import pytest
+from pydantic import ValidationError
+from training import schemas
+
+
+def test_create_invalid_topic(valid_quiz_create: schemas.QuizCreate):
+    with pytest.raises(ValidationError):
+        schemas.QuizCreate(
+            name=valid_quiz_create.name,
+            topic="Nonexistent",  # type: ignore
+            audience=valid_quiz_create.audience,
+            active=valid_quiz_create.active,
+            content=valid_quiz_create.content
+        )
+
+
+def test_create_invalid_audience(valid_quiz_create: schemas.QuizCreate):
+    with pytest.raises(ValidationError):
+        schemas.QuizCreate(
+            name=valid_quiz_create.name,
+            topic=valid_quiz_create.topic,
+            audience="Nonexistent",  # type: ignore
+            active=valid_quiz_create.active,
+            content=valid_quiz_create.content
+        )

--- a/training/tests/testdata.yaml
+++ b/training/tests/testdata.yaml
@@ -14,7 +14,7 @@ users:
 quizzes:
   - name: "Travel Training for Ministry of Magic"
     topic: "Travel"
-    audience: "Wizards"
+    audience: "AccountHoldersApprovingOfficials"
     active: true
     content:
       questions:
@@ -43,7 +43,7 @@ quizzes:
               correct: false
   - name: "Travel Training for Ministry of Magic"
     topic: "Travel"
-    audience: "Wizards"
+    audience: "AccountHoldersApprovingOfficials"
     active: false
     content:
       questions:


### PR DESCRIPTION
We're using string constants for some non-normalized database columns, namely quiz topic, quiz audience, and question type. This adds validation enforcement on those fields to ensure they only accept correct values.