### PR TITLE
Refactor to work with SMTP servers without auth

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -6,18 +6,16 @@ JWT_SECRET="something_hard_to_guess"
 # SMTP server to use for sending emails to users. For development, you can
 # create an Ethereal account to test emails (https://ethereal.email/). In
 # production, refer to the README.md file for instructions.
-SMTP_PASSWORD="smtp server password"
-SMTP_USER="name@example.com"
-SMTP_SERVER="smtp.example.com"
-SMTP_PORT=465
-SMTP_STARTTLS=false
-SMTP_SSL_TLS=true
+SMTP_PASSWORD="EXAMPLE"
+SMTP_USER="EXAMPLE@ethereal.email"
+SMTP_SERVER="smtp.ethereal.email"
+SMTP_PORT=587
 
 # These already have default values in config.py, but you can override them
 # here if needed.
-EMAIL_FROM="name@example.com"
-EMAIL_FROM_NAME="GSA SmartPay"
-EMAIL_SUBJECT="GSA SmartPay Training"
+# EMAIL_FROM="name@example.com"
+# EMAIL_FROM_NAME="GSA SmartPay"
+# EMAIL_SUBJECT="GSA SmartPay Training"
 
 # Datastores: For local testing, these defaults should be fine. In production,
 # these will be automatically populated from the cloud.gov VCAP_SERVICES data.

--- a/training/api/api_v1/loginless_flow.py
+++ b/training/api/api_v1/loginless_flow.py
@@ -16,7 +16,7 @@ router = APIRouter()
 
 
 @router.post("/get-link", status_code=status.HTTP_201_CREATED)
-async def send_link(
+def send_link(
     response: Response,
     user: Union[TempUser, IncompleteTempUser],
     dest: WebDestination,
@@ -47,7 +47,7 @@ async def send_link(
     # we may have the users going to pages other than quizes
     url = f"{settings.BASE_URL}/quiz/{dest.page_id}/?t={token}"
     try:
-        res = await send_email(to_email=user.email, name=user.name, link=url, training_title=dest.title)
+        res = send_email(to_email=user.email, name=user.name, link=url, training_title=dest.title)
     except Exception as e:
         logging.error("Error sending mail", e)
         raise HTTPException(

--- a/training/api/email.py
+++ b/training/api/email.py
@@ -28,7 +28,7 @@ email us at gsa_smartpay@gsa.gov.
 ''')
 
 
-async def send_email(to_email: EmailStr, name: str, link: str, training_title: str) -> JSONResponse:
+def send_email(to_email: EmailStr, name: str, link: str, training_title: str) -> JSONResponse:
     body = EMAIL_TEMPLATE.substitute({"name": name, "link": link, "training_title": training_title})
 
     message = EmailMessage()

--- a/training/config.py
+++ b/training/config.py
@@ -24,7 +24,7 @@ def vcap_services_settings(settings: BaseSettings) -> Dict[str, Any]:
     secrets = appenv.get_service(label="user-provided")
     if secrets and secrets.credentials["JWT_SECRET"]:
         config["JWT_SECRET"] = secrets.credentials["JWT_SECRET"]
-    if secrets and secrets.credentials["SMTP_PASSWORD"]:
+    if secrets and secrets.credentials.get("SMTP_PASSWORD", None):
         config["SMTP_PASSWORD"] = secrets.credentials["SMTP_PASSWORD"]
 
     return config
@@ -46,18 +46,16 @@ class Settings(BaseSettings):
 
     # for local dev, email setting should be added to .env
     # see .env_example for example
-    SMTP_USER: str
+    SMTP_USER: str | None
     SMTP_SERVER: str
     SMTP_PORT: int
-    EMAIL_FROM: EmailStr = "smartpay-noreply@gsa.gov"
+    EMAIL_FROM: EmailStr = EmailStr("smartpay-noreply@gsa.gov")
     EMAIL_FROM_NAME: str = "GSA SmartPay"
     EMAIL_SUBJECT: str = "GSA SmartPay Training"
-    SMTP_STARTTLS: bool
-    SMTP_SSL_TLS: bool
 
     # These are normally parsed from VCAP_SERVICES in Cloud Foundry, but can
     # be overridden locally by using the .env file.
-    SMTP_PASSWORD: str
+    SMTP_PASSWORD: str | None
     REDIS_HOST: str
     REDIS_PORT: int
     REDIS_PASSWORD: str


### PR DESCRIPTION
`fastapi_mail` seems to always require a username/password even when one does not exist for the SMTP server. This switches over to `smtplib` and makes the SMTP user/pass optional.