### PR TITLE
Add staging and production deployment workflows

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -1,0 +1,14 @@
+name: Deploy to cloud.gov dev space
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - training-front-end/**
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      environment: dev

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,0 +1,12 @@
+name: Deploy to cloud.gov prod space
+
+on:
+  push:
+    tags:
+      - release-*
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      environment: prod

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,14 @@
+name: Deploy to cloud.gov staging space
+
+on:
+  push:
+    branches:
+      - prod
+    paths-ignore:
+      - training-front-end/**
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      environment: staging

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,16 +1,16 @@
 name: Continuous deployment to cloud.gov
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - training-front-end/**
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: dev
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v2
 
@@ -20,7 +20,7 @@ jobs:
           cf_username: ${{ secrets.CG_USERNAME }}
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: gsa-smartpay
-          cf_space: dev
+          cf_space: ${{ inputs.environment }}
           command: >-
             cf update-user-provided-service smartpay-training-secrets -p '{
               "JWT_SECRET": "${{ secrets.JWT_SECRET }}",
@@ -33,9 +33,9 @@ jobs:
           cf_username: ${{ secrets.CG_USERNAME }}
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: gsa-smartpay
-          cf_space: dev
+          cf_space: ${{ inputs.environment }}
           command: >-
-            bin/cg-set-env.sh dev
+            bin/cg-set-env.sh ${{ inputs.environment }}
             BASE_URL=${{ vars.BASE_URL }}
             SMTP_USER=${{ vars.SMTP_USER }}
             SMTP_SERVER=${{ vars.SMTP_SERVER }}
@@ -49,8 +49,8 @@ jobs:
           cf_username: ${{ secrets.CG_USERNAME }}
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: gsa-smartpay
-          cf_space: dev
-          cf_vars_file: manifest-vars.dev.yml
+          cf_space: ${{ inputs.environment }}
+          cf_vars_file: manifest-vars.${{ inputs.environment }}.yml
 
       - name: Run database migrations
         uses: cloud-gov/cg-cli-tools@main
@@ -58,5 +58,5 @@ jobs:
           cf_username: ${{ secrets.CG_USERNAME }}
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: gsa-smartpay
-          cf_space: dev
+          cf_space: ${{ inputs.environment }}
           command: cf run-task smartpay-training -c "alembic upgrade head"

--- a/bin/cg-bootstrap-space.sh
+++ b/bin/cg-bootstrap-space.sh
@@ -11,7 +11,7 @@ org="gsa-smartpay"
 app_name="smartpay-training"
 space=$1
 
-if [ "$space" == "prod" ] ; then
+if [[ "$space" == "prod" || "$space" == "staging" ]]; then
   rds_plan="large-gp-psql-redundant"
   redis_plan="redis-3node"
 else

--- a/bin/cg-bootstrap-space.sh
+++ b/bin/cg-bootstrap-space.sh
@@ -19,6 +19,7 @@ else
   redis_plan="redis-dev"
 fi
 
+echo "Bootstrapping space: $space"
 echo "Using RDS plan: $rds_plan"
 echo "Using Redis plan: $redis_plan"
 echo

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -1,0 +1,3 @@
+env: prod
+memory: 4G
+instances: 2

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -1,0 +1,3 @@
+env: staging
+memory: 256M
+instances: 2


### PR DESCRIPTION
This rounds out the implementation of a full set of deployment workflows for `dev`, `staging`, and `prod` spaces on cloud.gov. It is modeled after the [FAC deployment process](https://github.com/GSA-TTS/FAC/blob/main/docs/deploying.md#standard-deployment-process).

tl;dr:
* Push to `main` = deployment to `dev` space
* Push to `prod` = deployment to `staging` space
* Create a tag in the format `release-*` = deployment to `prod` space

BTW, for the record, we also have a `test` space, but for that space we're just doing manual deployment so that we can hand pick items for testers to test.