### PR TITLE
Fix the new deploy actions

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       environment: dev
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -10,3 +10,4 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       environment: prod
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       environment: staging
+    secrets: inherit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure secrets
         uses: cloud-gov/cg-cli-tools@main


### PR DESCRIPTION
Secrets aren't automatically accessible to the child deploy workflows, so deployment fails. This update specifies that secrets should be inherited from the parent workflow.