### PR TITLE
adjusted footer spacing due to word break

### DIFF
--- a/training-front-end/src/components/GSAFooter.astro
+++ b/training-front-end/src/components/GSAFooter.astro
@@ -5,7 +5,7 @@
     <nav class="usa-footer__nav" aria-label="Footer navigation">
     <div class="usa-footer__primary-container grid-row grid-gap-1">
       <ul class="tablet:grid-col footer_list">
-        <li class="tablet:grid-col padding-x-2">For assistance with training related questions, contact us at <a href="mailto:gsa_smartpay@gsa.gov">gsa_smartpay@gsa.gov</a>.</li>
+        <li class="padding-right-4 tablet:grid-col tablet:padding-right-0">For assistance with training related questions, contact us at <a href="mailto:gsa_smartpay@gsa.gov">gsa_smartpay@gsa.gov</a>.</li>
         <li class="tablet:grid-col footer_seperator" >Visit the <a href="https://smartpay.gsa.gov/" >SmartPay program site</a> for more information about our commercial payment solution program.</li>
       </ul>
     </div>


### PR DESCRIPTION
there is extra space because email address is wrapped to next line due to no word break. Adjusted the spacing for desktop and mobile review to make spacing looks even on both side. 