### PR TITLE
Update comment

### DIFF
--- a/training-front-end/.env.development
+++ b/training-front-end/.env.development
@@ -1,2 +1,2 @@
-#PUBLIC_API_BASE_URL=https://smartpay-training-shiny-swan-ra.app.cloud.gov
+#PUBLIC_API_BASE_URL=https://smartpay-training-dev.app.cloud.gov
 PUBLIC_API_BASE_URL=http://localhost:8000


### PR DESCRIPTION
This just updates a comment in .env.develop to point to dev. This is mostly an excuse to rebuild the site and pick up the new env variable in pages.cloud.gov to point to the new backend.