### PR TITLE
Use .env for api setting

### DIFF
--- a/training-front-end/.env.production
+++ b/training-front-end/.env.production
@@ -1,0 +1,1 @@
+PUBLIC_API_BASE_URL=https://smartpay-training-dev.app.cloud.gov

--- a/training-front-end/.env.user_test
+++ b/training-front-end/.env.user_test
@@ -1,0 +1,1 @@
+PUBLIC_API_BASE_URL=https://smartpay-training-test.app.cloud.gov

--- a/training-front-end/.gitignore
+++ b/training-front-end/.gitignore
@@ -17,7 +17,6 @@ coverage/
 
 # environment variables
 .env
-.env.production
 
 # macOS-specific files
 .DS_Store


### PR DESCRIPTION
Allow .env.production to be added to  epo to allow us to remove the ENV variable in Pages. This will allow switching this based on astro build mode.