### PR TITLE
Style guide change to footer smartpay reference

### DIFF
--- a/training-front-end/src/components/GSAFooter.astro
+++ b/training-front-end/src/components/GSAFooter.astro
@@ -6,7 +6,7 @@
     <div class="usa-footer__primary-container grid-row grid-gap-1">
       <ul class="tablet:grid-col footer_list">
         <li class="padding-right-2 tablet:grid-col tablet:padding-right-0">For assistance with training related questions, contact us at <a href="mailto:gsa_smartpay@gsa.gov">gsa_smartpay@gsa.gov</a>.</li>
-        <li class="padding-left-2 tablet:grid-col footer_seperator tablet:padding-left-4" >Visit the <a href="https://smartpay.gsa.gov/" >SmartPay program site</a> for more information about our commercial payment solution program.</li>
+        <li class="padding-left-2 tablet:grid-col footer_seperator tablet:padding-left-4" >Visit the <a href="https://smartpay.gsa.gov/" >GSA SmartPay program website</a> for more information about our commercial payment solution program.</li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
- Changes program website link text to conform to style guide
  - Adds `GSA` to `SmartPay`
  -  Changes `site` to `website`  