### PR TITLE
Mmeyer/182 fix email link

### DIFF
--- a/training-front-end/src/components/TrainingReportDownload.vue
+++ b/training-front-end/src/components/TrainingReportDownload.vue
@@ -34,7 +34,7 @@
       heading="You are not authorized to receive reports."
     >
       Your email account is not authorized to access training reports. If you should be authorized, you can 
-      <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the SmartPay team to gain access.</a>
+      <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the SmartPay team</a> to gain access.
     </USWDSAlert>
   </section>
 </template>

--- a/training-front-end/src/components/TrainingReportDownload.vue
+++ b/training-front-end/src/components/TrainingReportDownload.vue
@@ -33,7 +33,8 @@
       class="usa-alert"
       heading="You are not authorized to receive reports."
     >
-      Your email account is not authorized to access training reports. If you should be authorized, you can contact the SmartPay team to gain access.
+      Your email account is not authorized to access training reports. If you should be authorized, you can 
+      <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the SmartPay team to gain access.</a>
     </USWDSAlert>
   </section>
 </template>

--- a/training-front-end/src/components/TrainingReportIndex.vue
+++ b/training-front-end/src/components/TrainingReportIndex.vue
@@ -18,7 +18,7 @@
     if (err.message == 'Unauthorized'){
       err = {
         name: 'You are not authorized to receive reports.',
-        message: 'Your email account is not authorized to access training reports. If you should be authorized, you can contact the SmartPay team to gain access.'
+        message: 'Your email account is not authorized to access training reports. If you should be authorized, you can <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the SmartPay team</a> to gain access.'
       }
       setError(err)
     }
@@ -36,7 +36,7 @@
           status="error"
           :heading="error.name"
         >
-          {{ error.message }}
+          <span v-html="error.message"></span>
         </USWDSAlert>
 
         <Loginless


### PR DESCRIPTION
This adds the mailto link to the error alerts when a non-report user attempts to generate reports.