### PR TITLE
use upper case for 'Select all'; fix a couple linting warnings

### DIFF
--- a/training-front-end/src/components/AdminAgencySelect.vue
+++ b/training-front-end/src/components/AdminAgencySelect.vue
@@ -75,7 +75,7 @@
         class="usa-button usa-button--unstyled margin-bottom-2"
         @click="selectAllBureaus"
       >
-        select all
+        Select all
       </button>
       <div
         id="selected-agencies"

--- a/training-front-end/src/components/TrainingReportDownload.vue
+++ b/training-front-end/src/components/TrainingReportDownload.vue
@@ -44,7 +44,12 @@
       heading="You are not authorized to receive reports."
     >
       Your email account is not authorized to access training reports. If you should be authorized, you can 
-      <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the SmartPay team</a> to gain access.
+      <a
+        class="usa-link"
+        href="mailto:gsa_smartpay@gsa.gov"
+      >
+        contact the SmartPay team
+      </a> to gain access.
     </USWDSAlert>
   </section>
 </template>

--- a/training-front-end/src/components/TrainingReportIndex.vue
+++ b/training-front-end/src/components/TrainingReportIndex.vue
@@ -36,7 +36,8 @@
           status="error"
           :heading="error.name"
         >
-          <span v-html="error.message"></span>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <span v-html="error.message" />
         </USWDSAlert>
 
         <Loginless


### PR DESCRIPTION
- Corrects the `select all` link changing it to `Select all` 
- Fixes a couple warning coming from the linter.