### PR TITLE
Adjust flow to deny token exchange for non-admins

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,3 +14,4 @@ applications:
       - name: smartpay-training-oauth-client
         parameters:
           redirect_uri: ((oauth_redirect_uri))
+          allowpublic: true

--- a/training/api/api_v1/auth.py
+++ b/training/api/api_v1/auth.py
@@ -3,7 +3,7 @@ import jwt
 from training.api.auth import UAAJWTUser
 from training.config import settings
 from training.repositories import UserRepository
-from training.schemas import UserJWT
+from training.schemas import UserJWT, User
 from training.api.deps import user_repository
 
 
@@ -27,9 +27,18 @@ def auth_exchange(
     if not db_user:
         # TODO: Log token exchange failure
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid user."
         )
+
+    user = User.from_orm(db_user)
+    if not user.is_admin():
+        # TODO: Log failure
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to login."
+        )
+
     jwt_user = UserJWT.from_orm(db_user)
     encoded_jwt = jwt.encode(jwt_user.dict(), settings.JWT_SECRET, algorithm="HS256")
     # TODO: Log token exchange success

--- a/training/api/api_v1/auth.py
+++ b/training/api/api_v1/auth.py
@@ -27,7 +27,7 @@ def auth_exchange(
     if not db_user:
         # TODO: Log token exchange failure
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid user."
         )
 

--- a/training/schemas/user.py
+++ b/training/schemas/user.py
@@ -6,7 +6,7 @@ from training.schemas.role import Role
 
 def convert_roles(cls, input) -> list[str]:
     # Converts roles from a list of dicts to a simple list of role name strings.
-    return list(map(lambda role: role.name, input))
+    return [role["name"] for role in input]
 
 
 class UserBase(BaseModel):
@@ -25,6 +25,10 @@ class User(UserBase):
     agency: Agency
     roles: list[Role]
     report_agencies: list[Agency]
+
+    def is_admin(self) -> bool:
+        role_names = [role.name.upper() for role in self.roles]
+        return "Admin".upper() in role_names
 
     class Config:
         orm_mode = True

--- a/training/schemas/user.py
+++ b/training/schemas/user.py
@@ -6,7 +6,7 @@ from training.schemas.role import Role
 
 def convert_roles(cls, input) -> list[str]:
     # Converts roles from a list of dicts to a simple list of role name strings.
-    return [role["name"] for role in input]
+    return [role.name for role in input]
 
 
 class UserBase(BaseModel):

--- a/training/tests/factories.py
+++ b/training/tests/factories.py
@@ -36,3 +36,7 @@ class AgencySchemaFactory(ModelFactory[schemas.Agency]):
 
 class AgencyCreateSchemaFactory(ModelFactory[schemas.AgencyCreate]):
     __model__ = schemas.AgencyCreate
+
+
+class RoleSchemaFactory(ModelFactory[schemas.Role]):
+    __model__ = schemas.Role

--- a/training/tests/test_auth_login.py
+++ b/training/tests/test_auth_login.py
@@ -91,7 +91,7 @@ def test_auth_exchange_valid_jwt_nonexistent_user(decode_jwt, find_by_email, reg
         "/api/v1/auth/exchange",
         headers={"Authorization": f"Bearer {regular_user_uaa_jwt}"}
     )
-    assert response.status_code == 401
+    assert response.status_code == 403
 
 
 @patch("training.repositories.UserRepository.find_by_email")

--- a/training/tests/test_auth_login.py
+++ b/training/tests/test_auth_login.py
@@ -1,0 +1,95 @@
+import jwt
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from training import models
+from training.main import app
+from training.config import settings
+from training.tests.factories import RoleSchemaFactory, UserSchemaFactory
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def admin_user_data() -> dict:
+    admin_role = RoleSchemaFactory.build(name="Admin")
+    admin_user = UserSchemaFactory.build(roles=[admin_role], report_agencies=[])
+    return admin_user.dict()
+
+
+@pytest.fixture
+def regular_user_data() -> dict:
+    regular_user = UserSchemaFactory.build(report_agencies=[])
+    return regular_user.dict()
+
+
+@pytest.fixture
+def admin_user_uaa_jwt(admin_user_data):
+    return jwt.encode(admin_user_data, "test_uaa_key", algorithm="HS256")
+
+
+@pytest.fixture
+def regular_user_uaa_jwt(regular_user_data):
+    return jwt.encode(regular_user_data, "test_uaa_key", algorithm="HS256")
+
+
+@pytest.fixture
+def invalid_jwt(admin_user_data: dict):
+    return jwt.encode(admin_user_data, 'hakzors', algorithm="HS256")
+
+
+def test_auth_metadata():
+    response = client.get(
+        "/api/v1/auth/metadata"
+    )
+    assert response.status_code == 200
+    assert response.json()["authority"] == settings.AUTH_AUTHORITY_URL
+    assert response.json()["client_id"] == settings.AUTH_CLIENT_ID
+
+
+@patch("training.repositories.UserRepository.find_by_email")
+@patch("training.api.auth.UAAJWTUser.decode_jwt")
+def test_auth_exchange_valid_jwt_admin_user(decode_jwt, find_by_email, admin_user_data, admin_user_uaa_jwt):
+    decode_jwt.return_value = dict(admin_user_data)
+    find_by_email.return_value = models.User(**admin_user_data)
+
+    response = client.post(
+        "/api/v1/auth/exchange",
+        headers={"Authorization": f"Bearer {admin_user_uaa_jwt}"}
+    )
+    assert response.status_code == 200
+
+
+@patch("training.repositories.UserRepository.find_by_email")
+@patch("training.api.auth.UAAJWTUser.decode_jwt")
+def test_auth_exchange_valid_jwt_regular_user(decode_jwt, find_by_email, regular_user_data, regular_user_uaa_jwt):
+    decode_jwt.return_value = dict(regular_user_data)
+    find_by_email.return_value = models.User(**regular_user_data)
+
+    response = client.post(
+        "/api/v1/auth/exchange",
+        headers={"Authorization": f"Bearer {regular_user_uaa_jwt}"}
+    )
+    assert response.status_code == 403
+
+
+@patch("training.repositories.UserRepository.find_by_email")
+@patch("training.api.auth.UAAJWTUser.decode_jwt")
+def test_auth_exchange_valid_jwt_nonexistent_user(decode_jwt, find_by_email, regular_user_data, regular_user_uaa_jwt):
+    decode_jwt.return_value = dict(regular_user_data)
+    find_by_email.return_value = None
+
+    response = client.post(
+        "/api/v1/auth/exchange",
+        headers={"Authorization": f"Bearer {regular_user_uaa_jwt}"}
+    )
+    assert response.status_code == 401
+
+
+def test_auth_exchange_invalid_jwt(invalid_jwt):
+    response = client.post(
+        "/api/v1/auth/exchange",
+        headers={"Authorization": f"Bearer {invalid_jwt}"}
+    )
+    assert response.status_code == 403

--- a/training/tests/test_user_schema.py
+++ b/training/tests/test_user_schema.py
@@ -1,0 +1,12 @@
+from .factories import UserSchemaFactory, RoleSchemaFactory
+
+
+def test_is_admin_with_admin_user():
+    admin_role = RoleSchemaFactory.build(name="Admin")
+    admin_user = UserSchemaFactory.build(roles=[admin_role])
+    assert admin_user.is_admin()
+
+
+def test_is_admin_with_nonadmin_user():
+    regular_user = UserSchemaFactory.build()
+    assert not regular_user.is_admin()


### PR DESCRIPTION
This updates `/auth/exchange` to issue a JWT only if the user has the `Admin` role. At this point, we do not expect that anyone other than admins will use SecureAuth to login. Having a single authorization failure point will make it more straightforward to display an unauthorized error message on the front end.