### PR TITLE
Accommodate change in user.roles 

### DIFF
--- a/training-front-end/src/components/TrainingReportDownload.vue
+++ b/training-front-end/src/components/TrainingReportDownload.vue
@@ -5,7 +5,7 @@
   import USWDSAlert from './USWDSAlert.vue'
 
   const user = useStore(profile)
-  const isReportUser = computed(() => user.value.roles.some(role => role.name == 'Report'))
+  const isReportUser = computed(() => user.value.roles.includes('Report'))
   const base_url = import.meta.env.PUBLIC_API_BASE_URL
   const report_url = `${base_url}/api/v1/users/download-user-quiz-completion-report`
 

--- a/training-front-end/src/components/__tests__/TrainingReportIndex.spec.js
+++ b/training-front-end/src/components/__tests__/TrainingReportIndex.spec.js
@@ -20,13 +20,13 @@ describe("TrainingReportIndex", async () => {
   })
 
   it('Shows download screen', async () => {
-    profile.set({name:"Amelia Sedley", jwt:"some-token-value", roles:[{'name': "Report"}]})
+    profile.set({name:"Amelia Sedley", jwt:"some-token-value", roles:["Report"]})
     const wrapper = await mount(TrainingReportIndex)
     expect(wrapper.text()).toContain('Download Your Report')
   })
 
   it('shows error when user is know but does not have correct roles', async () => {
-    profile.set({name:"Amelia Sedley", jwt:"some-token-value", roles:[{'name': "SomeOtherRole"}]})
+    profile.set({name:"Amelia Sedley", jwt:"some-token-value", roles:["SomeOtherRole"]})
     const wrapper = await mount(TrainingReportIndex)
     expect(wrapper.text()).toContain('You are not authorized')
   })


### PR DESCRIPTION
Changes training report component to expect a list of role names in user rather than list of objects when determining is someone has a "Report" role. Closes #250 