### PR TITLE
Secure training certificates

### DIFF
--- a/training-front-end/src/components/CertificateTable.vue
+++ b/training-front-end/src/components/CertificateTable.vue
@@ -18,9 +18,13 @@
   }
 
   const certificates = ref([]) 
-
+ 
   onMounted(async() => {
-      certificates.value = await fetch(`${api_url}/api/v1/certificates/${user.value.id}`).then((r) => r.json())
+      certificates.value = await fetch(`${api_url}/api/v1/certificates/`, {
+        method: 'GET',
+        headers: {'Authorization': `Bearer ${user.value.jwt}`}
+      }
+       ).then((r) => r.json())
     })
 
   const data_format = { year:"numeric", month:"long", day:"numeric"}
@@ -69,13 +73,22 @@
           {{ formatted_date(cert.completion_date) }}
         </td>
         <td>
-          <a 
-            :href="`${api_url}/api/v1/certificate/${cert.id}`" 
-            class="usa-button usa-button--unstyled" 
-            download="sample.pdf"
+          <form
+            :action="`${api_url}/api/v1/certificate/${cert.id}`" 
+            method="post"
           >
-            <FileDownLoad /> Download
-          </a>
+            <input 
+              type="hidden"
+              name="jwtToken"
+              :value="user.jwt"
+            >
+            <button
+              class="usa-button usa-button--unstyled"
+              type="submit"
+            >
+              <FileDownLoad /> Download
+            </button>
+          </form>
         </td>
       </tr>
     </tbody>

--- a/training-front-end/src/components/QuizResults.vue
+++ b/training-front-end/src/components/QuizResults.vue
@@ -4,6 +4,13 @@
     import ErrorIcon from './icons/ErrorIcon.vue';
     import QuizResult from './QuizResult.vue';
     import USWDS from "@uswds/uswds/js";
+    import FileDownLoad from "./icons/FileDownload.vue"
+
+    import { useStore } from '@nanostores/vue'
+    import { profile} from '../stores/user'
+
+    const user = useStore(profile)
+
     const { accordion } = USWDS;
     const api_base = import.meta.env.PUBLIC_API_BASE_URL
 
@@ -47,13 +54,22 @@
       <p>
         You got <b>{{ result_string }}</b> questions correct, for a total score of <b>{{ percentage }}%</b>, which meets the 75% or higher requirement to pass.
       </p>
-      <a 
-        :href="quiz_certificate_url"
-        download="sample.pdf"
-        class="usa-button usa-button--outline margin-bottom-3"
-      >
-        Download your certificate of completion
-      </a>
+      <form
+            :action=quiz_certificate_url 
+            method="post"
+          >
+            <input 
+              type="hidden"
+              name="jwtToken"
+              :value="user.jwt"
+            >
+            <button
+              class="usa-button usa-button--outline margin-bottom-3"
+              type="submit"
+            >
+              <FileDownLoad /> Download your certificate of completion
+            </button>
+          </form>
     </div>
     <div v-else>
       <div class="usa-prose">

--- a/training-front-end/src/components/__tests__/CertificateTable.spec.js
+++ b/training-front-end/src/components/__tests__/CertificateTable.spec.js
@@ -68,11 +68,11 @@ describe('CertificateTable', async () => {
     const rows = wrapper.findAll('tr') 
     expect(rows.length).toBe(3)
 
-    const anchorOne = rows[1].find('a')
-    expect(anchorOne.attributes('href')).toBe("http://localhost:8000/api/v1/certificate/2")
+    const anchorOne = rows[1].find('form')
+    expect(anchorOne.attributes('action')).toBe("http://localhost:8000/api/v1/certificate/2")
 
-    const anchorTwo = rows[2].find('a')
-    expect(anchorTwo.attributes('href')).toBe("http://localhost:8000/api/v1/certificate/68")
+    const anchorTwo = rows[2].find('form')
+    expect(anchorTwo.attributes('action')).toBe("http://localhost:8000/api/v1/certificate/68")
   })
 
   it('show correct message when the user has not taken a quiz', async () => {

--- a/training/api/api_v1/certificates.py
+++ b/training/api/api_v1/certificates.py
@@ -1,31 +1,41 @@
-from typing import List
+from typing import List, Any
 from fastapi import APIRouter, status, HTTPException, Depends, Response
 from training.schemas import UserCertificate
 from training.repositories import CertificateRepository
 from training.api.deps import certificate_repository
 from training.services.certificate import Certificate
+from training.api.auth import JWTUser, user_from_form
+
 
 router = APIRouter()
 
 
-@router.get("/certificates/{user_id}", response_model=List[UserCertificate])
-def get_certificates_by_userid(user_id: int, repo: CertificateRepository = Depends(certificate_repository)):
-    db_user_certificates = repo.get_certificates_by_userid(user_id)
+@router.get("/certificates/", response_model=List[UserCertificate])
+def get_certificates_by_userid(
+    repo: CertificateRepository = Depends(certificate_repository),
+    user: dict[str, Any] = Depends(JWTUser())
+):
+    db_user_certificates = repo.get_certificates_by_userid(user["id"])
     if db_user_certificates is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return db_user_certificates
 
 
-@router.get("/certificate/{id}", response_model=UserCertificate)
+@router.post("/certificate/{id}", response_model=UserCertificate)
 def get_certificate_by_id(
     id: int,
     repo: CertificateRepository = Depends(certificate_repository),
-    certificate: Certificate = Depends(Certificate)
+    certificate: Certificate = Depends(Certificate),
+    user=Depends(user_from_form)
 ):
-
     db_user_certificate = repo.get_certificate_by_id(id)
+
     if db_user_certificate is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    if db_user_certificate.user_id != user["id"]:
+        raise HTTPException(status_code=401, detail="Not Authorized")
+
     pdf_bytes = certificate.generate_pdf(
         db_user_certificate.quiz_name,
         db_user_certificate.user_name,


### PR DESCRIPTION
- Changes API to require JWT. 
- Uses user from jwt to lookup certificates rather then trusting the front end value
- Change front end code to send jwt when:
  - listing certificates
  - downloading certificate from certificate list
  - downloading certificate after taking quiz