### PR TITLE
Save auth metadata in session storage

### DIFF
--- a/training-front-end/src/services/auth.ts
+++ b/training-front-end/src/services/auth.ts
@@ -18,7 +18,7 @@ export default class AuthService {
   }
 
   static async instance(): Promise<AuthService> {
-    let authMetadata = window.localStorage.getItem("authMetadata")
+    let authMetadata = window.sessionStorage.getItem("authMetadata")
 
     if (authMetadata) {
       authMetadata = JSON.parse(authMetadata)
@@ -28,7 +28,7 @@ export default class AuthService {
       const metadataResponse = await fetch(metadataUrl)
       authMetadata = await metadataResponse.json()
       if (authMetadata) {
-        window.localStorage.setItem("authMetadata", JSON.stringify(authMetadata))
+        window.sessionStorage.setItem("authMetadata", JSON.stringify(authMetadata))
       }
     }
 


### PR DESCRIPTION
The auth metadata stored in localStorage is specific to each environment. When we started using multiple environments, this presented a problem where the user would not be able to log in unless they manually went in to clear their localStorage data. This change switches from using localStorage to sessionStorage. That way, the user just has to end their session in order to be able to sign in to a different environment.