### PR TITLE
Dev

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,7 +3,7 @@ name: Deploy to cloud.gov dev space
 on:
   push:
     branches:
-      - main
+      - dev
     paths-ignore:
       - training-front-end/**
 

--- a/manifest-vars.dev.yml
+++ b/manifest-vars.dev.yml
@@ -2,5 +2,5 @@ env: dev
 memory: 256M
 instances: 1
 oauth_redirect_uri:
-  - https://federalist-2e11f2c8-970f-44f5-acc8-b47ef6c741ad.sites.pages.cloud.gov/site/gsa/smartpay-training/
-  - https://federalist-2e11f2c8-970f-44f5-acc8-b47ef6c741ad.sites.pages.cloud.gov/site/gsa/smartpay-training/auth_callback
+  - https://federalist-2e11f2c8-970f-44f5-acc8-b47ef6c741ad.sites.pages.cloud.gov/preview/gsa/smartpay-training/dev/
+  - https://federalist-2e11f2c8-970f-44f5-acc8-b47ef6c741ad.sites.pages.cloud.gov/preview/gsa/smartpay-training/dev/auth_callback

--- a/training-front-end/.env.dev
+++ b/training-front-end/.env.dev
@@ -1,0 +1,4 @@
+PUBLIC_API_BASE_URL=https://smartpay-training-dev.app.cloud.gov
+# in minutes
+PUBLIC_SESSION_TIME_OUT=60
+PUBLIC_SESSION_WARNING_TIME=5

--- a/training-front-end/.env.development
+++ b/training-front-end/.env.development
@@ -1,3 +1,5 @@
+# This is the env file for local dev, not the cloud.gov dev environment
+# it will be used when runing `npm run` dev (or `astro dev`)
 #PUBLIC_API_BASE_URL=https://smartpay-training-dev.app.cloud.gov
 PUBLIC_API_BASE_URL=http://localhost:8000
 # in minutes

--- a/training-front-end/.env.staging
+++ b/training-front-end/.env.staging
@@ -1,0 +1,4 @@
+PUBLIC_API_BASE_URL=https://smartpay-training-staging.app.cloud.gov
+# in minutes
+PUBLIC_SESSION_TIME_OUT=60
+PUBLIC_SESSION_WARNING_TIME=5

--- a/training-front-end/bin/build.sh
+++ b/training-front-end/bin/build.sh
@@ -1,0 +1,21 @@
+#/bin/bash
+
+set -e
+
+echo $BRANCH
+
+case "$BRANCH" in
+main)
+    MODE="production" ;;
+staging)
+    MODE="staging" ;;
+dev)
+    MODE="dev" ;;
+*)
+    MODE="dev" ;;
+esac
+
+echo "building for:"
+echo $MODE
+
+astro build  --mode $MODE

--- a/training-front-end/package.json
+++ b/training-front-end/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "./bin/build.sh", 
     "preview": "astro preview",
     "astro": "astro",
     "test:unit": "vitest --environment jsdom --root .",

--- a/training-front-end/src/services/auth.ts
+++ b/training-front-end/src/services/auth.ts
@@ -18,7 +18,7 @@ export default class AuthService {
   }
 
   static async instance(): Promise<AuthService> {
-    let authMetadata = window.localStorage.getItem("authMetadata")
+    let authMetadata = window.sessionStorage.getItem("authMetadata")
 
     if (authMetadata) {
       authMetadata = JSON.parse(authMetadata)
@@ -28,7 +28,7 @@ export default class AuthService {
       const metadataResponse = await fetch(metadataUrl)
       authMetadata = await metadataResponse.json()
       if (authMetadata) {
-        window.localStorage.setItem("authMetadata", JSON.stringify(authMetadata))
+        window.sessionStorage.setItem("authMetadata", JSON.stringify(authMetadata))
       }
     }
 


### PR DESCRIPTION
- Set dev branch to deploy to Dev environment on cloud.gov
- Incorporate changes from https://github.com/GSA/smartpay-training/pull/280
- Use bash script for deploying front end to allow different set of environment variables depending on the BRANCH reported by cloud.gov pages 
- Change manifest for dev environment on cloud.gov to point the auth callback to the development front-end (this change is already in place on cloud.gov)
