### PR TITLE
Mmeyer/api documentation

### DIFF
--- a/training/api/api_v1/certificates.py
+++ b/training/api/api_v1/certificates.py
@@ -15,6 +15,9 @@ def get_certificates_by_userid(
     repo: CertificateRepository = Depends(certificate_repository),
     user: dict[str, Any] = Depends(JWTUser())
 ):
+    '''
+    Returns a list of certificates for `user`
+    '''
     db_user_certificates = repo.get_certificates_by_userid(user["id"])
     if db_user_certificates is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/training/api/api_v1/loginless_flow.py
+++ b/training/api/api_v1/loginless_flow.py
@@ -32,7 +32,12 @@ def page_lookup():
     }
 
 
-@router.post("/get-link", status_code=status.HTTP_201_CREATED)
+@router.post("/get-link",
+             status_code=status.HTTP_201_CREATED,
+             responses={
+                 200: {"description": 'OK, but user details needed'},
+                 201: {"description": "Token created"}
+                 })
 def send_link(
     response: Response,
     user: Union[TempUser, IncompleteTempUser],
@@ -42,11 +47,13 @@ def send_link(
     page_id_lookup: dict = Depends(page_lookup)
 ):
     '''
-    Sends the user an email with a token embedded in a link back to the
-    frontend section the user made the request from (the 'dest' parameter).
-    The token is a key to the Redis cache. When they use the link to return,
-    we have confidence they could access the email and look up their idendity
-    from the cache. In cases where we add the user to the cache this repondes with an HTTP 201.
+    Create a link with an embedded token.\f
+
+    This link is sent via email pointing back to the frontend section the user
+    made the request from (the 'dest' parameter). The token is a key to the Redis
+    cache. When they use the link to return, we have confidence they could access
+    the email and look up their idendity from the cache. In cases where we add the
+    user to the cache this repondes with an HTTP 201.
 
     If the `user` body paremeter is an IncompleteTempUser (only has an email)
     this will query the database to see if the user exist. If the user does not exist

--- a/training/api/api_v1/loginless_flow.py
+++ b/training/api/api_v1/loginless_flow.py
@@ -10,16 +10,17 @@ from training.api.deps import user_repository
 
 from training.config import settings
 from training.api.email import send_email
-from training.api.auth import JWTUser
 
 router = APIRouter()
 
 
-# This lookup table allows the front-end to send a simple pageID
-# but be redirected to a more complex path. It also allows the
-# backend to provide errors if the user does not have the appropriate
-# role for a front-end page (although the data itself is secured by the API)
 def page_lookup():
+    '''
+    Returns a lookup table to allow the front-end to send a simple pageID
+    but be redirected to a more complex path. It also allows the
+    backend to provide errors if the user does not have the appropriate
+    role for a front-end page (although the data itself is secured by the API)
+    '''
     return {
         'certificates': {'path': '/certificates/', 'required_roles': []},
         'training_reports': {'path': '/training_reports', 'required_roles': ['Report']},
@@ -40,6 +41,22 @@ def send_link(
     cache: UserCache = Depends(UserCache),
     page_id_lookup: dict = Depends(page_lookup)
 ):
+    '''
+    Sends the user an email with a token embedded in a link back to the
+    frontend section the user made the request from (the 'dest' parameter).
+    The token is a key to the Redis cache. When they use the link to return,
+    we have confidence they could access the email and look up their idendity
+    from the cache. In cases where we add the user to the cache this repondes with an HTTP 201.
+
+    If the `user` body paremeter is an IncompleteTempUser (only has an email)
+    this will query the database to see if the user exist. If the user does not exist
+    this should return an HTTP 200 to indicate to the frontend that no user was created
+    and it should ask them for more information (name, agency). If the email does exist,
+    we send that email a link.
+
+    A TempUser (has name, agency, and email) indicates a new user. We add this information
+    to the cache and send a link, but not the database until they have validated the email.
+    '''
     try:
         required_roles = page_id_lookup[dest.page_id]['required_roles']
     except KeyError:
@@ -48,12 +65,17 @@ def send_link(
             detail=f"Unkown Page Id {dest.page_id}"
         )
     if isinstance(user, IncompleteTempUser):
+        # we only got the email from the front end
         user_from_db = repo.find_by_email(user.email)
         if user_from_db is None:
             response.status_code = status.HTTP_200_OK
             return {'new': True}
         else:
             role_names = set(role.name for role in user_from_db.roles)
+            # Check to make sure the user has permission to access the destination.
+            # This allows the front end to tell the user they are not authorized
+            # to access this destination instead of finding out after they get the email
+            # and try the link.
             if not all(role in role_names for role in required_roles):
                 logging.info(
                     f"{user.email} does not have the required role to access {page_id_lookup[dest.page_id]['path']}"
@@ -89,20 +111,18 @@ def send_link(
         )
 
 
-@router.get("/user-info")
-def user_info(user=Depends(JWTUser())):
-    # This will eventually query the DB for the
-    # info we want to display on a user's home page
-    # But for now just send the jwt data
-    return user
-
-
 @router.get("/get-user/{token}")
 async def get_user(
     token: str,
     repo: UserRepository = Depends(user_repository),
     cache: UserCache = Depends(UserCache)
 ):
+    '''
+    Looks up the token in the redis cache to get a user who clicked a link with
+    a token. If the user is not yet in the database (a new registration), create
+    the user in the DB. Send back a user object with a JWT that the front end
+    can use to authenticate.
+    '''
     try:
         user = cache.get(token)
     except Exception as e:

--- a/training/api/auth.py
+++ b/training/api/auth.py
@@ -1,12 +1,13 @@
-from fastapi import Request, HTTPException, Depends, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from typing import Annotated
-import jwt
 import json
+from typing import Annotated
+from urllib.request import urlopen
+
+from fastapi import Request, HTTPException, Depends, status
+from fastapi import Form
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import jwt
 from jwt.exceptions import InvalidTokenError
 from training.config import settings
-from urllib.request import urlopen
-from fastapi import Form
 
 
 class JWTUser(HTTPBearer):

--- a/training/api/auth.py
+++ b/training/api/auth.py
@@ -10,7 +10,16 @@ from fastapi import Form
 
 
 class JWTUser(HTTPBearer):
-    # Represents a JWT issued by our API.
+    '''
+    Represents a JWT issued by our API.
+    This class can be used as a dependency in FastAPI routes like:
+
+    @router.get("/somepath", response_model=SomeModel)
+    def my_function( user: dict[str, Any] = Depends(JWTUser())):
+
+    to generate a user with a valid token.
+
+    '''
 
     async def __call__(self, request: Request):
         credentials: HTTPAuthorizationCredentials | None = await super().__call__(request)
@@ -32,7 +41,10 @@ class JWTUser(HTTPBearer):
 
 
 class UAAJWTUser(HTTPBearer):
-    # Represents a JWT issued by an OAuth server.
+    '''
+    Represents a JWT issued by an OAuth server.
+    Used as part of the Admin SecureAuth flow
+    '''
 
     async def __call__(self, request: Request):
         credentials: HTTPAuthorizationCredentials | None = await super().__call__(request)
@@ -120,6 +132,16 @@ class UAAJWTUser(HTTPBearer):
 
 
 class RequireRole:
+    '''
+    Used for api routes that should be limited to specific roles. These
+    roles will be encoded in the JWT when the user authenticates. This
+    checkes the roles in the JWT and compares them to the roles this
+    class was initialized with. It can be used like this to ensure we
+    either have a user with the `Admin` role or response with a 401:
+
+    @router.post("/some_route", response_model=SomeModel
+    def create_user(user=Depends(RequireRole(["Admin"]))):
+    '''
     def __init__(self, required_roles: list[str]) -> None:
         self.required_roles = set(required_roles)
 
@@ -136,6 +158,14 @@ class RequireRole:
 
 
 def user_from_form(jwtToken: Annotated[str, Form()]):
+    '''
+    This allows POST requests to send a token as part of form-encoded request.
+    There are places in the front-end where we want to download a file, but we also
+    need to authenticate the user. We cannot pass a JWT with a simple html <a>, so instead
+    use a form to POST the request. The form can then include the JWT as in input. This
+    function is used to decode and validate the JWT in that case. See: "/certificate/{id}"
+    for an example.
+    '''
     try:
         return jwt.decode(jwtToken, settings.JWT_SECRET, algorithms=["HS256"])
     except jwt.exceptions.InvalidTokenError:

--- a/training/api/email.py
+++ b/training/api/email.py
@@ -1,4 +1,3 @@
-import logging
 from string import Template
 from pydantic import EmailStr
 from smtplib import SMTP
@@ -53,7 +52,6 @@ def send_email(to_email: EmailStr, name: str, link: str, training_title: str) ->
         try:
             smtp.send_message(message)
         except Exception as e:
-            logging.error("Error sending email", e)
-            raise SendEmailError
+            raise SendEmailError from e
         finally:
             smtp.quit()


### PR DESCRIPTION
- Small cleanup to add docstrings. 
- Prevents double logging on email failures. 
- Remove unused API endpoint for `get("/user-info")`