### PR TITLE
remove the wildcard CORS origin and add origins to help with local dev

### DIFF
--- a/training/main.py
+++ b/training/main.py
@@ -11,12 +11,16 @@ app = FastAPI(
 origins = [
     "http://localhost",
     "https://localhost",
-    "*"
+    "http://localhost:3000",
+    "https://localhost:3000",
+    "http://127.0.0.1:3000",
+    "https://training.smartpay.gov",
 ]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
+    allow_origin_regex=r'https://federalist.*\.sites\.pages\.cloud\.gov',
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
This removes the wildcard CORS setting to address the low security finding around cross-origin requests. It also adds localhost domains to avoid errors when running locally. 