### PR TITLE
get agency when getting certificates to schema validates correctly

### DIFF
--- a/training/repositories/certificate.py
+++ b/training/repositories/certificate.py
@@ -26,6 +26,10 @@ class CertificateRepository(BaseRepository[models.QuizCompletion]):
     def get_certificates_by_userid(self, user_id: int) -> list[UserCertificate]:
         results = (self._session.query(models.QuizCompletion.id.label("id"), models.User.id.label("user_id"),
                                        models.User.name.label("user_name"), models.Quiz.id.label("quiz_id"),
-                                       models.Quiz.name.label("quiz_name"), models.QuizCompletion.submit_ts.label("completion_date")).join(models.User)
-                   .join(models.Quiz).filter(models.QuizCompletion.passed, models.User.id == user_id).all())
+                                       models.Agency.name.label("agency"), models.Quiz.name.label("quiz_name"),
+                                       models.Quiz.name.label("quiz_name"), models.QuizCompletion.submit_ts.label("completion_date"))
+                                .join(models.User, models.QuizCompletion.user_id == models.User.id)
+                                .join(models.Agency, models.User.agency_id == models.Agency.id)
+                                .join(models.Quiz, models.QuizCompletion.quiz_id == models.Quiz.id)
+                                .filter(models.QuizCompletion.passed, models.User.id == user_id).all())
         return results


### PR DESCRIPTION
This fixes #315 — when we changed the schema of the certificates to include the agency, we overlooked that the certificate listing also returns a list of these objects. The validation was failing since these did not have the agency.