### PR TITLE
Improve test coverage

### DIFF
--- a/training/api/auth.py
+++ b/training/api/auth.py
@@ -23,16 +23,14 @@ class JWTUser(HTTPBearer):
     '''
 
     async def __call__(self, request: Request):
+        # The parent HTTPBearer default's to raising an error if there is
+        # no authentication or the authentication schema is not bearer
         credentials: HTTPAuthorizationCredentials | None = await super().__call__(request)
-        if credentials:
-            if not credentials.scheme == "Bearer":
-                raise HTTPException(status_code=403, detail="Invalid authentication scheme.")
-            user = self.decode_jwt(credentials.credentials)
-            if user is None:
-                raise HTTPException(status_code=403, detail="Invalid or expired token.")
-            return user
-        else:
-            raise HTTPException(status_code=403, detail="Invalid authorization code.")
+
+        user = self.decode_jwt(credentials.credentials)
+        if user is None:
+            raise HTTPException(status_code=403, detail="Invalid or expired token.")
+        return user
 
     def decode_jwt(self, token: str):
         try:
@@ -48,16 +46,12 @@ class UAAJWTUser(HTTPBearer):
     '''
 
     async def __call__(self, request: Request):
+
         credentials: HTTPAuthorizationCredentials | None = await super().__call__(request)
-        if credentials:
-            if not credentials.scheme == "Bearer":
-                raise HTTPException(status_code=403, detail="Invalid authentication scheme.")
-            user = self.decode_jwt(credentials.credentials)
-            if user is None:
-                raise HTTPException(status_code=403, detail="Invalid or expired token.")
-            return user
-        else:
-            raise HTTPException(status_code=403, detail="Invalid authorization code.")
+        user = self.decode_jwt(credentials.credentials)
+        if user is None:
+            raise HTTPException(status_code=403, detail="Invalid or expired token.")
+        return user
 
     def decode_jwt(self, token: str):
         token_header = jwt.get_unverified_header(token)

--- a/training/tests/test_auth.py
+++ b/training/tests/test_auth.py
@@ -92,6 +92,11 @@ class TestAuth:
         assert response.status_code == 403
         assert response.json() == {'detail': 'Invalid or expired token.'}
 
+    def test_invalid_auth_scheme(self, goodJWT):
+        response = client.get("/home", headers={"Authorization": f"Non_Bearer {goodJWT}"})
+        assert response.status_code == 403
+        assert response.json() == {'detail': 'Invalid authentication credentials'}
+
     def test_missing_jwt(self):
         response = client.get("/home")
         assert response.status_code == 403


### PR DESCRIPTION
- Removes redundant logic from HTTPAuth subclass. FastApi's [HTTPBearer class](https://github.com/tiangolo/fastapi/blob/bfde8f3ef20dc338bbce8a0ff0f4b441c54d5b64/fastapi/security/http.py#L100C7-L100C17) already tests for the inclusion of the `bearer` scheme and `credentials` and will raise a 403 exception if these are not present. The code removed was not reachable. 
- Adds a few more tests for the edge cases, and to improve coverage.