### PR TITLE
Make A/OPC travel training title consistent.

### DIFF
--- a/training-front-end/src/pages/quiz/[training_id].astro
+++ b/training-front-end/src/pages/quiz/[training_id].astro
@@ -27,7 +27,7 @@ export function getStaticPaths() {
       header: 'Travel Training',
       subhead: 'Program Coordinators',
       training_id: "training_travel_pc",
-      title: "Travel Training for Agency/Organization Program Coordinators (A/OPCs)"
+      title: "Travel Training for Program Coordinators"
     },
     {
       topic: 'Purchase',


### PR DESCRIPTION
Changes the title for travel training for program coordinators to be consistent with other a/opc training. The email will now read:
> Click the link below to access your GSA SmartPayⓇ Travel Training for Program Coordinators quiz.
