### PR TITLE
address content issue

### DIFF
--- a/training-front-end/src/components/TrainingReportDownload.vue
+++ b/training-front-end/src/components/TrainingReportDownload.vue
@@ -48,7 +48,7 @@
         class="usa-link"
         href="mailto:gsa_smartpay@gsa.gov"
       >
-        contact the SmartPay team
+        contact the GSA SmartPay team
       </a> to gain access.
     </USWDSAlert>
   </section>

--- a/training-front-end/src/components/TrainingReportIndex.vue
+++ b/training-front-end/src/components/TrainingReportIndex.vue
@@ -18,7 +18,7 @@
     if (err.message == 'Unauthorized'){
       err = {
         name: 'You are not authorized to receive reports.',
-        message: 'Your email account is not authorized to access training reports. If you should be authorized, you can <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the SmartPay team</a> to gain access.'
+        message: 'Your email account is not authorized to access training reports. If you should be authorized, you can <a class="usa-link" href="mailto:gsa_smartpay@gsa.gov">contact the GSA SmartPay team</a> to gain access.'
       }
       setError(err)
     }

--- a/training-front-end/src/content/training_purchase/lesson03.mdx
+++ b/training-front-end/src/content/training_purchase/lesson03.mdx
@@ -16,7 +16,7 @@ order: 3
 - To become a GSA SmartPay Purchase card/account holder, your personal credit history is not criteria for receiving a purchase card/account. In addition, use of the purchase card/account will not affect your personal credit history. 
 - New applicants should receive their GSA SmartPay Purchase card/account from the contractor bank within 10-14 calendar days from the time the application is submitted by your A/OPC. 
 - Replacements for lost, stolen, broken or otherwise unusable cards will be sent within 48 hours of the agency/organization request. 
-- In the case of an emergency, such as response to a natural disaster, threat to national security and military mobilization, the contractor bank will send the GSA Smartpay Purchase card/account within 24 hours of the request.
+- In the case of an emergency, such as response to a natural disaster, threat to national security and military mobilization, the contractor bank will send the GSA SmartPay Purchase card/account within 24 hours of the request.
 
 ### Verifying Your Card/Account
 After receipt of your card/account the following steps should be taken:

--- a/training/api/email.py
+++ b/training/api/email.py
@@ -29,13 +29,13 @@ email us at gsa_smartpay@gsa.gov.
 def send_email(to_email: EmailStr, name: str, link: str, training_title: str) -> None:
 
     if training_title and "certificate" in training_title.lower():
-        subject = "GSA SmartPayⓇ training certificate(s)"
+        subject = "GSA SmartPay® training certificate(s)"
         email_subject = "Access your GSA SmartPay training certificate(s)"
     elif training_title and "report" in training_title.lower():
-        subject = "GSA SmartPayⓇ reporting information for A/OPCs"
+        subject = "GSA SmartPay® reporting information for A/OPCs"
         email_subject = "Access to GSA SmartPay training report"
     else:
-        subject = f"GSA SmartPayⓇ {training_title} quiz"
+        subject = f"GSA SmartPay® {training_title} quiz"
         email_subject = f"Access GSA SmartPay {training_title} quiz"
 
     body = EMAIL_TEMPLATE.substitute({"name": name, "link": link, "subject": subject})

--- a/training/tests/test_email.py
+++ b/training/tests/test_email.py
@@ -58,7 +58,7 @@ class TestEmail:
         args, _ = smtp_instance.send_message.call_args
         email_message = args[0]
         message = email_message.get_content()
-        assert 'Click the link below to access your GSA SmartPayⓇ training certificate(s)' in message
+        assert 'Click the link below to access your GSA SmartPay® training certificate(s)' in message
         assert email_message['Subject'] == 'Access your GSA SmartPay training certificate(s)'
 
     def test_email_report(self, smtp_instance):
@@ -66,7 +66,7 @@ class TestEmail:
         args, _ = smtp_instance.send_message.call_args
         email_message = args[0]
         message = email_message.get_content()
-        assert 'Click the link below to access your GSA SmartPayⓇ reporting information for A/OPCs' in message
+        assert 'Click the link below to access your GSA SmartPay® reporting information for A/OPCs' in message
         assert email_message['Subject'] == 'Access to GSA SmartPay training report'
 
     def test_email_quiz(self, smtp_instance):
@@ -74,5 +74,5 @@ class TestEmail:
         args, _ = smtp_instance.send_message.call_args
         email_message = args[0]
         message = email_message.get_content()
-        assert 'Click the link below to access your GSA SmartPayⓇ Ad Sales quiz.' in message
+        assert 'Click the link below to access your GSA SmartPay® Ad Sales quiz.' in message
         assert email_message['Subject'] == 'Access GSA SmartPay Ad Sales quiz'


### PR DESCRIPTION
-  Search for Smartpay to ensure P is capitalized everywhere
-  Make sure "GSA" precedes every reference to SmartPay
-  Ensure that the (R) mark is only used on the first reference on each page / document