### PR TITLE
address home page URl 404 issue

### DIFF
--- a/training-front-end/src/components/AuthRedirect.vue
+++ b/training-front-end/src/components/AuthRedirect.vue
@@ -14,6 +14,7 @@
   const auth = await AuthService.instance()
   const error = ref(null)
   const authRedirectTarget = useStore(redirectTarget)
+  const base_url = import.meta.env.BASE_URL
 
   auth.loginCallback().then(async () => {
     const uaaToken = await auth.getAccessToken()
@@ -34,7 +35,7 @@
       >
         {{ error }}
       </USWDSAlert>
-      <p><a href="/">Return to Home</a></p>
+      <p><a :href="base_url">Return to Home</a></p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
for user that are not admin user, if they try to use admin portal, it will have error message and Go back to Home link, previously the Go back to home link render 404 error, code fix is merged and deployed in dev branch for back end testing