### PR TITLE
PlantUML docs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": [
+    "vue.volar",
+    "vue.vscode-typescript-vue-plugin",
+    "jebbs.plantuml"
+  ]
 }

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,8 @@
+# System Diagrams
+
+This directory contains plantUML files for creating various system diagrams documenting the SmartPay systems inlcuding the website, training site, and the 889 tool. These are primarily used for ATO documentation, but should be kept up-to-date when changes are made to the system.
+
+See [https://plantuml.com](https://plantuml.com) for documentation. 
+
+## Viewing and exporting
+There are multiple way to process and view plantUML. [Quick Start Guide to PlantUML](https://plantuml.com/starting) has links to various tools. We have found the easiest way to manage these files is with the VS Code [PlantUML extension](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml). With this extension installed you can use Alt + D to start PlantUML preview (option + D on MacOS). Right clicking in the plantUML file will also bring up a contextual menu to export the files. 


### PR DESCRIPTION
Add basic documentation for viewing/generating plantUML diagrams and include the proper extension in VScode recommendations. 