### PR TITLE
Change Prod Env

### DIFF
--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -1,5 +1,5 @@
 env: prod
-memory: 4G
+memory: 512mb
 instances: 2
 oauth_redirect_uri:
   - https://training.smartpay.gsa.gov

--- a/training-front-end/.env.production
+++ b/training-front-end/.env.production
@@ -1,4 +1,4 @@
-PUBLIC_API_BASE_URL=https://smartpay-training-staging.app.cloud.gov
+PUBLIC_API_BASE_URL=https://smartpay-training-prod.app.cloud.gov
 # in minutes
 PUBLIC_SESSION_TIME_OUT=30
 PUBLIC_SESSION_WARNING_TIME=5


### PR DESCRIPTION
Bring memory in line with current deployed use. Connect prod front-end to prod backend

This also changes the memory use. 4GB was crashing with memory errors. We can try to push this up after we confirm things are working.