### PR TITLE
wrap content in usa-prose to make tables work on printable pdf

### DIFF
--- a/training-front-end/src/pages/training_fleet_pc/printable.astro
+++ b/training-front-end/src/pages/training_fleet_pc/printable.astro
@@ -28,7 +28,7 @@ const entries = await Promise.all(content_components)
         </button>
 
         {entries.map(item => (  
-          <div style="page-break-after: auto;">
+          <div class="usa-prose" style="page-break-after: auto;">
             <h1 class="text-primary">{item.data.title}</h1> 
             <item.Content />
           </div>

--- a/training-front-end/src/pages/training_purchase/printable.astro
+++ b/training-front-end/src/pages/training_purchase/printable.astro
@@ -28,7 +28,7 @@ const entries = await Promise.all(content_components)
         </button>
 
         {entries.map(item => (  
-          <div style="page-break-after: auto;">
+          <div  class="usa-prose" style="page-break-after: auto;">
             <h1 class="text-primary">{item.data.title}</h1> 
             <item.Content />
           </div>

--- a/training-front-end/src/pages/training_purchase_pc/printable.astro
+++ b/training-front-end/src/pages/training_purchase_pc/printable.astro
@@ -28,7 +28,7 @@ const entries = await Promise.all(content_components)
         </button>
 
         {entries.map(item => (  
-          <div style="page-break-after: auto;">
+          <div  class="usa-prose" style="page-break-after: auto;">
             <h1 class="text-primary">{item.data.title}</h1> 
             <item.Content />
           </div>

--- a/training-front-end/src/pages/training_travel/printable.astro
+++ b/training-front-end/src/pages/training_travel/printable.astro
@@ -28,7 +28,7 @@ const entries = await Promise.all(content_components)
         </button>
 
         {entries.map(item => (  
-          <div style="page-break-after: auto;">
+          <div  class="usa-prose" style="page-break-after: auto;">
             <h1 class="text-primary">{item.data.title}</h1> 
             <item.Content />
           </div>

--- a/training-front-end/src/pages/training_travel_pc/printable.astro
+++ b/training-front-end/src/pages/training_travel_pc/printable.astro
@@ -28,7 +28,7 @@ const entries = await Promise.all(content_components)
         </button>
 
         {entries.map(item => (  
-          <div style="page-break-after: auto;">
+          <div  class="usa-prose" style="page-break-after: auto;">
             <h1 class="text-primary">{item.data.title}</h1> 
             <item.Content />
           </div>


### PR DESCRIPTION
This fixes and issue that prevented tables from rendering correctly in the "printable" view of the trainings. It also make headings and line lengths more closely match the rendering on the site.