### PR TITLE
Resolves accessibility flag for WCAG 2.1 compliance

### DIFF
--- a/training-front-end/src/components/TrainingCard.astro
+++ b/training-front-end/src/components/TrainingCard.astro
@@ -5,7 +5,7 @@ aria-label is used to address accessiblity issues with same link text linking to
 */
 const { item, category } = Astro.props;
 const aria_label_training = `${item.training_link_text} for ${category}`;
-const aria_label_quiz = `Take the ${item.header.toLowerCase()} quiz for ${category}`;
+const aria_label_quiz = `Take the quiz ${item.header.toLowerCase()} for ${category}`;
 
 ---
 


### PR DESCRIPTION
As described in #441 this is a nuanced accessibility flag, which requires a matching string for accessible labels and visual text.

This fix isn't ideal, since it coerces the accessible name into a matching string. But there's a unique accessible case for doing so, described in [this article](https://dequeuniversity.com/rules/axe/4.8/label-content-name-mismatch) and the [WCAG guidance](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html):

> Speech input users can interact with a webpage by speaking the visible text labels of menus, links, and buttons that appear on the screen. It is confusing to speech input users when they say a visible text label they see, but the speech command does not work because the component's accessible (programmatic) name does not match the visible label. When a user interface component has a visible text label — whether it be real text or an image of text — that text must also be found in the component's accessible (programmatic) name. When the visible label and accessible (programmatic) name for interactive components are in sync, speech input users can effectively interact with those components.

If the program and vendor partners agree, we recommend adjusting the `aria-label` to accommodate this use case.