### PR TITLE
Feature/569 june content updates

### DIFF
--- a/training-front-end/src/content/training_fleet_pc/lesson01.mdx
+++ b/training-front-end/src/content/training_fleet_pc/lesson01.mdx
@@ -14,7 +14,6 @@ Established in 1998, the GSA SmartPay program is the world’s largest governmen
 - GSA SmartPay Purchase.
 - GSA SmartPay Travel.
 - GSA SmartPay Fleet.
-- GSA SmartPay Tax Advantage Travel.
 - GSA SmartPay Integrated. 
 
 Through the Master Contract with multiple banks, the GSA SmartPay program enables agencies/organizations across the federal government to obtain payment solutions to support mission needs. The Master Contract, administered by GSA, is a fixed price, indefinite delivery, indefinite quantity (IDIQ) contract. The maximum base period for the initial order is four years with three, three-year options.

--- a/training-front-end/src/content/training_purchase/lesson01.mdx
+++ b/training-front-end/src/content/training_purchase/lesson01.mdx
@@ -15,7 +15,6 @@ Established in 1998, the GSA SmartPay program is the world’s largest governmen
 - GSA SmartPay Purchase.
 - GSA SmartPay Travel.
 - GSA SmartPay Fleet.
-- GSA SmartPay Tax Advantage Travel.
 - GSA SmartPay Integrated. 
 
 Through the Master Contract with multiple banks, the GSA SmartPay program enables agencies/organizations across the federal government to obtain payment solutions to support mission needs. The Master Contract, administered by GSA, is a fixed price, indefinite delivery, indefinite quantity (IDIQ) contract. The maximum base period for the initial order is four years with three, three-year options.

--- a/training-front-end/src/content/training_purchase_pc/lesson01.mdx
+++ b/training-front-end/src/content/training_purchase_pc/lesson01.mdx
@@ -14,7 +14,6 @@ Established in 1998, the GSA SmartPay program is the world’s largest governmen
 - GSA SmartPay Purchase.
 - GSA SmartPay Travel.
 - GSA SmartPay Fleet.
-- GSA SmartPay Tax Advantage Travel.
 - GSA SmartPay Integrated. 
 
 Through the Master Contract with multiple banks, the GSA SmartPay program enables agencies/organizations across the federal government to obtain payment solutions to support mission needs. The Master Contract, administered by GSA, is a fixed price, indefinite delivery, indefinite quantity (IDIQ) contract. The maximum base period for the initial order is four years with three, three-year options.

--- a/training-front-end/src/content/training_travel/lesson01.mdx
+++ b/training-front-end/src/content/training_travel/lesson01.mdx
@@ -16,7 +16,6 @@ Established in 1998, the GSA SmartPay program is the world’s largest governmen
 - GSA SmartPay Purchase.
 - GSA SmartPay Travel.
 - GSA SmartPay Fleet.
-- GSA SmartPay Tax Advantage Travel.
 - GSA SmartPay Integrated. 
 
 Through the Master Contract with multiple banks, the GSA SmartPay program enables agencies/organizations across the federal government to obtain payment solutions to support mission needs. The Master Contract, administered by GSA, is a fixed price, indefinite delivery, indefinite quantity (IDIQ) contract. The maximum base period for the initial order is four years with three, three-year options.

--- a/training-front-end/src/content/training_travel_pc/lesson01.mdx
+++ b/training-front-end/src/content/training_travel_pc/lesson01.mdx
@@ -15,7 +15,6 @@ Established in 1998, the GSA SmartPay program is the world’s largest governmen
 - GSA SmartPay Purchase.
 - GSA SmartPay Travel.
 - GSA SmartPay Fleet.
-- GSA SmartPay Tax Advantage Travel.
 - GSA SmartPay Integrated. 
 
 Through the Master Contract with multiple banks, the GSA SmartPay program enables agencies/organizations across the federal government to obtain payment solutions to support mission needs. The Master Contract, administered by GSA, is a fixed price, indefinite delivery, indefinite quantity (IDIQ) contract. The maximum base period for the initial order is four years with three, three-year options.


### PR DESCRIPTION
Update Lesson One (1) for all training types to remove GSA SmartPay Tax Advantage Travel from the list of business lines:

Card/Account Holders and Approving Officials - Travel Training
Card/Account Holders and Approving Officials - Purchase Training
Agency/Organization Program Coordinators - Travel Training
Agency/Organization Program Coordinators - Purchase Training
Agency/Organization Program Coordinators - Fleet Training