### PR TITLE
Admin: Deleting Reporting Access in the UI is not deleting the record…

### DIFF
--- a/training-front-end/src/components/AdminEditReporting.vue
+++ b/training-front-end/src/components/AdminEditReporting.vue
@@ -41,6 +41,7 @@ function editUserAgencies(e, checked) {
     })
   } else {
     agencies.value = agencies.value.filter(agency => agency.id != e.id)
+    emit('save', props.user.id, agencies.value)
   }
 }
 

--- a/training-front-end/src/components/GspcQuestions.vue
+++ b/training-front-end/src/components/GspcQuestions.vue
@@ -51,10 +51,14 @@
   }
 
   function previous_question(){
-    question_index.value -= 1
-    const state = { page: question_index.value }
-    const url = ""
-    history.pushState(state, "", url)
+    if (question_index.value > 0){
+      question_index.value -= 1
+      const state = { page: question_index.value }
+      const url = ""
+      history.pushState(state, "", url)
+    } else {
+      show_intro.value = true
+    }
   }
 
   function select_answer(event) {
@@ -115,7 +119,7 @@
         :disabled="!can_submit"
         @click="submit_quiz"
       >
-        Submit quiz
+        Submit
       </button>
       <!--display spinner along with submit button in one row for desktop-->
       <div
@@ -145,7 +149,6 @@
     </div>
     <br>
     <button
-      v-if="question_index"
       id="previous-button"
       type=""
       class="usa-button usa-button--outline"

--- a/training-front-end/src/components/__tests__/GspcQuestions.spec.js
+++ b/training-front-end/src/components/__tests__/GspcQuestions.spec.js
@@ -58,16 +58,16 @@ describe('GspcQuestions', () => {
     expect(button.element.disabled).toBe(false)
   })
 
-  it('Previous button does not show on first question', async () => {
+  it('Previous button does show on first question', async () => {
     const wrapper = shallowMount(GspcQuestions, {
       props: { questions }
     })
 
     await startForm(wrapper)
 
-    // Assert that the previous button does not exist
+    // Assert that the previous button does exist
     const previousButton = wrapper.find('#previous-button');
-    expect(previousButton.exists()).toBe(false);
+    expect(previousButton.exists()).toBe(true);
   })
 
   it('navigates to the next question and back', async () => {


### PR DESCRIPTION
Production deployment for the following issues:
- Admin: Deleting Reporting Access in the UI is not deleting the record in the Database [#605](https://github.com/GSA/smartpay-training/issues/605)
- Configure the system to end sessions at 15 minutes to meet the requirement CA-9 [#606](https://github.com/GSA/smartpay-training/issues/606)
- User Research Feedback - UI Changes to GSPC [#604](https://github.com/GSA/smartpay-training/issues/604)