### PR TITLE
Update spinner to stop when error is retuned.

### DIFF
--- a/training-front-end/src/components/AdminEditUserDetails.vue
+++ b/training-front-end/src/components/AdminEditUserDetails.vue
@@ -79,8 +79,6 @@ async function update_user_info() {
 
   try{
     let updatedUser = await adminRepository.updateUser(props.userToEdit.id, user_data)
-    is_saving.value = false
-    show_spinner.value = false
     let successMessage = `Successfully updated ${updatedUser.email}`
     emit('completeUserUpdate', successMessage)
   } catch(err){
@@ -89,6 +87,9 @@ async function update_user_info() {
       message: err
     })
   }
+
+  is_saving.value = false
+  show_spinner.value = false
 }
 
 function clearErrors(){


### PR DESCRIPTION
When editing your user profile, a system error is displayed. However, the spinner persists on the page and the buttons are disabled. A user has to refresh the page for the button to be enabled.