### PR TITLE
Refresh admin search results when canceling edit from report editing page

### DIFF
--- a/training-front-end/src/components/AdminSearchUser.vue
+++ b/training-front-end/src/components/AdminSearchUser.vue
@@ -70,6 +70,9 @@
   function cancelEdit(){
     setSelectedUser(undefined)
     setSelectedAgencyId(undefined)
+    // refresh search on cancel from edit reporting page as you can also update user details on the page without
+    // updating the reporting access. Refresh page to display updated details.
+    search()
   }
   
   async function updateUserSuccess(message) {


### PR DESCRIPTION
Refreshed admin search result on cancel from the edit reporting page as you can also update user details on the page without updating the reporting access. Refresh page to display updated details.